### PR TITLE
이메일 정규표현식 버그 수정

### DIFF
--- a/src/main/java/com/fourfourfour/damoa/domain/member/controller/MemberController.java
+++ b/src/main/java/com/fourfourfour/damoa/domain/member/controller/MemberController.java
@@ -63,7 +63,7 @@ public class MemberController {
     public ResponseEntity<BaseResponseDto<?>> checkEmailDuplicate(@PathVariable String email) {
         log.info("이메일 중복 확인 [{}]", email);
 
-        String emailChk = "^[a-zA-Z0-9]([._-]?[a-zA-Z0-9])*@[a-zA-Z0-9]([-_.]?[a-zA-Z0-9])*.[a-zA-Z]$";
+        String emailChk = "^[a-zA-Z0-9]([-_.]?[a-zA-Z0-9])*@[a-zA-Z0-9]([-_.]?[a-zA-Z0-9])*\\.[a-zA-Z]{2,3}$";
         if (!email.matches(emailChk)) {
             throw new IllegalArgumentException(ErrorMessage.PATTERN_MEMBER_EMAIL);
         }

--- a/src/main/java/com/fourfourfour/damoa/domain/member/controller/dto/MemberRequestDto.java
+++ b/src/main/java/com/fourfourfour/damoa/domain/member/controller/dto/MemberRequestDto.java
@@ -20,7 +20,7 @@ public class MemberRequestDto {
     @NoArgsConstructor
     public static class RegisterDto {
 
-        @Pattern(regexp = "^[a-zA-Z0-9]([._-]?[a-zA-Z0-9])*@[a-zA-Z0-9]([-_.]?[a-zA-Z0-9])*.[a-zA-Z]$", message = "{pattern.member.email}")
+        @Pattern(regexp = "^[a-zA-Z0-9]([-_.]?[a-zA-Z0-9])*@[a-zA-Z0-9]([-_.]?[a-zA-Z0-9])*\\.[a-zA-Z]{2,3}$", message = "{pattern.member.email}")
         private String email;
 
         @Pattern(regexp = "^((?=.*[a-z])(?=.*\\d)((?=.*\\W)|(?=.*[A-Z]))|(?=.*\\W)(?=.*[A-Z])((?=.*\\d)|(?=.*[a-z]))).{8,20}$", message = "{pattern.member.password}")

--- a/src/test/java/com/fourfourfour/damoa/domain/member/service/MemberServiceImplTest.java
+++ b/src/test/java/com/fourfourfour/damoa/domain/member/service/MemberServiceImplTest.java
@@ -27,7 +27,7 @@ class MemberServiceImplTest {
     @Autowired
     private PasswordEncoder passwordEncoder;
 
-    private MemberRequestDto.RegisterDto registerDto1;
+    private MemberRequestDto.RegisterDto registerDto1, registerDto2;
 
     @BeforeEach
     public void setUp() {
@@ -43,23 +43,45 @@ class MemberServiceImplTest {
                 .serviceTerm(true)
                 .privacyTerm(true)
                 .build();
+
+        registerDto2 = MemberRequestDto.RegisterDto.builder()
+                .email("test1@damoa.com")
+                .password(passwordEncoder.encode("Abcdefg1!"))
+                .nickname("testNickname2")
+                .gender("male")
+                .birthDate(LocalDate.of(1998, 10, 11))
+                .job("전문직")
+                .serviceTerm(true)
+                .privacyTerm(true)
+                .build();
     }
 
     @Test
-    @DisplayName("이메일 중복 체크")
-    void isEmailDuplication() {
+    @DisplayName("이메일 중복 확인 - 성공")
+    void emailDuplicationSuccess() {
         String email = registerDto1.getEmail();
 
-        // 이메일 중복 체크
+        // 이메일 중복 확인 검증
         boolean isUsingEmail = memberService.isEmailDuplication(email);
         assertThat(isUsingEmail).isFalse();
+    }
+
+    @Test
+    @DisplayName("이메일 중복 확인 - 중복일 때")
+    void emailDuplicationFail() {
+        String email1 = registerDto1.getEmail();
+
+        // 회원가입 전 이메일 중복 체크
+        boolean isUsingEmail1 = memberService.isEmailDuplication(email1);
+        assertThat(isUsingEmail1).isFalse();
 
         // 회원가입
         memberService.register(registerDto1.toServiceDto());
 
-        // 이메일 중복 체크
-        isUsingEmail = memberService.isEmailDuplication(email);
-        assertThat(isUsingEmail).isTrue();
+        // 회원가입 된 이메일로 중복 확인 검증
+        String email2 = registerDto2.getEmail();
+        boolean isUsingEmail2 = memberService.isEmailDuplication(email2);
+        assertThat(isUsingEmail2).isTrue();
     }
 
     @Test


### PR DESCRIPTION
## 확인사항

- [x] 테스트 코드를 작성하셨나요?
- [x] 모든 테스트 코드가 정상적으로 실행되나요?
- [x] 포스트맨으로 API 테스트를 진행하셨나요?

## 어떤 이유로 PR을 하셨나요?

- [ ] feature
- [x] bug-fix
- [ ] refactor
- [ ] 기타(아래 설명에 자세한 내용을 기입해주세요)

## PR 내용:

이메일 정규표현식 버그를 수정하였습니다.

[이메일을 판별하는 기준]
1. @가 첫번째 나온 경우
![image](https://user-images.githubusercontent.com/48669011/164873946-b056f5f3-03b6-4cfb-b999-0de635fba3bd.png)
2. .(dot)이 마지막에 나온 경우
![image](https://user-images.githubusercontent.com/48669011/164873955-6644cd85-4552-42fc-927d-eff298b908ed.png)
3. @가 없는 경우
![image](https://user-images.githubusercontent.com/48669011/164874081-0b660935-783b-425b-b892-c501dd6e8f6e.png)
4. .(dot)이 없는 경우
![image](https://user-images.githubusercontent.com/48669011/164874089-c6de842c-7032-4ae5-9517-1e1888f553d4.png)
5. @앞에 .(dot)이 붙은 경우
![image](https://user-images.githubusercontent.com/48669011/164873992-61abb4b7-0863-479e-8303-6682eccdc1c8.png)

위 기준을 충족하도록 수정하였습니다.

또한, 도메인이 다양할 수 있기 때문에 제한을 풀었습니다.
![image](https://user-images.githubusercontent.com/48669011/164874048-d318531e-4a28-4402-98bb-be2171c9be96.png)



